### PR TITLE
DAT-18360: return null for expiration date

### DIFF
--- a/src/main/java/liquibase/AwsLicenseService.java
+++ b/src/main/java/liquibase/AwsLicenseService.java
@@ -161,9 +161,4 @@ public class AwsLicenseService implements LicenseService {
     public void reset() {
         lazyLoader.clearCache();
     }
-
-    @Override
-    public Date getExpirationDate() {
-        return getDate();
-    }
 }


### PR DESCRIPTION
The expiration date cannot be calculated using the AWS APIs, so return null instead.