### PR TITLE
DAT-18500: Bump aws version to match other aws extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>licensemanager</artifactId>
-            <version>2.25.38</version>
+            <version>2.27.12</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>liquibase-aws-license-service</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <url>http://www.liquibase.com</url>
     <licenses>


### PR DESCRIPTION
Every pro extension is currently on 2.27.12. 