### PR TITLE
🔧 Update Dockerfile OSS-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Liquibase image as the base
-FROM liquibase/liquibase:4.29.1
+FROM liquibase/liquibase:4.29.2
 
 # Add the AWS License Service Extension using the Liquibase Package Manager (LPM)
 RUN lpm update && lpm add liquibase-aws-license-service


### PR DESCRIPTION
1. official-docker image updated: https://github.com/docker-library/official-images/pull/17483 as there was an issue in dependabot creating a PR . 
2. Fix is here: https://github.com/liquibase/liquibase-aws-license-service/pull/54. 

For now updating the docker version manually in Dockerfile