### PR TITLE
🔧 Update dependabot.yml to create PR for docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "hourly"
+      interval: "daily"
     pull-request-branch-name:
       separator: "-"
     labels:


### PR DESCRIPTION
- fix: `.github/dependabot.yml`:  issue with Dependabot https://github.com/liquibase/liquibase-aws-license-service/network/updates  

`The property '#/updates/2/schedule/interval' value "hourly" did not match one of the following values: daily, weekly, monthly`

 [liquibase-aws-license-service/.github/dependabot.yml at main · liquibase/liquibase-aws-license-service](https://github.com/liquibase/liquibase-aws-license-service/blob/main/.github/dependabot.yml#L25)