### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM liquibase/liquibase:4.29.2
 
 # Add the AWS License Service Extension using the Liquibase Package Manager (LPM)
-RUN lpm update && lpm add liquibase-aws-license-service
+RUN lpm update && lpm add liquibase-aws-license-service --global
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]


### PR DESCRIPTION
fix: `Dockerfile`: adding `--global` to the `lpm add` command. It will get the liquibase home path and install it there.