### PR TITLE
DAT-18816: add support for different PRO extensions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM liquibase/liquibase:4.29.2
 # Marker which indicates this is a Liquibase docker container
 ENV DOCKER_AWS_LIQUIBASE=true
 
-# Add the AWS License Service and other extensions using the Liquibase Package Manager (LPM)
+# Add support for Liquibase PRO extensions using the Liquibase Package Manager (LPM)
 RUN lpm update && \
     lpm add liquibase-aws-license-service liquibase-s3-extension liquibase-aws-secrets-manager \
             liquibase-commercial-mongodb liquibase-commercial-dynamodb liquibase-checks --global

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,14 @@ ENV DOCKER_AWS_LIQUIBASE=true
 
 # Add support for Liquibase PRO extensions using the Liquibase Package Manager (LPM)
 RUN lpm update && \
-    lpm add liquibase-aws-license-service liquibase-s3-extension liquibase-aws-secrets-manager \
-            liquibase-commercial-mongodb liquibase-commercial-dynamodb liquibase-checks --global
+    lpm add \
+    liquibase-aws-license-service \
+    liquibase-s3-extension \
+    liquibase-aws-secrets-manager \
+    liquibase-commercial-mongodb \
+    liquibase-commercial-dynamodb \
+    liquibase-checks \
+    --global
 
 
 # Default command to display Liquibase version

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM liquibase/liquibase:4.29.2
 # Marker which indicates this is a Liquibase docker container
 ENV DOCKER_AWS_LIQUIBASE=true
 
-# Add the AWS License Service Extension using the Liquibase Package Manager (LPM)
-RUN lpm update && lpm add liquibase-aws-license-service --global
+# Add the AWS License Service and other extensions using the Liquibase Package Manager (LPM)
+RUN lpm update && \
+    lpm add liquibase-aws-license-service liquibase-s3-extension liquibase-aws-secrets-manager \
+            liquibase-commercial-mongodb liquibase-commercial-dynamodb liquibase-checks --global
+
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]


### PR DESCRIPTION
feat: `Dockerfile`: add support for different PRO extensions in Dockerfile. Ran it locally to check what packages and versions are getting added: `liquibase-aws-license-service@v1.0.2` has  `extension` as Category. Do we want it to be `pro` instead? 

cc: @suryaaki2 @abrackx @filipelautert  

 
![Screenshot 2024-10-10 at 11 57 20 AM](https://github.com/user-attachments/assets/1280bc88-8f21-447b-a14d-29b8faefae28)


