### PR TITLE
CRUC-48 Remove Individual IAM Users and Transition to OIDC or Specific Static Credentials

### DIFF
--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -74,8 +74,7 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-              aws-access-key-id: ${{ secrets.AWS_MP_ACCESS_KEY }}
-              aws-secret-access-key: ${{ secrets.AWS_MP_ACCESS_KEY_ID }}
+              role-to-assume: ${{ secrets.AWS_MP_GITHUB_OIDC_ROLE_ARN_AWS_LICENSE_SERVICE }}
               aws-region: us-east-1
 
           - name: Set up QEMU
@@ -135,8 +134,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_MP_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_MP_ACCESS_KEY_ID }}
+          role-to-assume: ${{ secrets.AWS_MP_GITHUB_OIDC_ROLE_ARN_AWS_LICENSE_SERVICE }}
           aws-region: us-east-1
 
       - name: Set up QEMU


### PR DESCRIPTION
This pull request includes changes to the AWS credentials configuration in the deployment workflow for the marketplace extension. The most important changes involve updating the method of authentication to use a role assumption instead of direct access keys.

Changes to AWS credentials configuration:

* [`.github/workflows/deploy-extension-to-marketplace.yml`](diffhunk://#diff-3c746d30714ebf2e3ecea3317afb825b8ee2e00847ce7f00cc9d1602151667cdL77-R77): Updated the AWS credentials configuration to use `role-to-assume` with `AWS_MP_GITHUB_OIDC_ROLE_ARN_AWS_LICENSE_SERVICE` instead of `aws-access-key-id` and `aws-secret-access-key`. [[1]](diffhunk://#diff-3c746d30714ebf2e3ecea3317afb825b8ee2e00847ce7f00cc9d1602151667cdL77-R77) [[2]](diffhunk://#diff-3c746d30714ebf2e3ecea3317afb825b8ee2e00847ce7f00cc9d1602151667cdL138-R137)