### PR TITLE
DAT-18926: use @main from build logic

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   nightly-build:
-    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main
     with:
       nightly: true
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@main
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
     secrets: inherit

--- a/.github/workflows/extension-update-pom.yml
+++ b/.github/workflows/extension-update-pom.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   update-pom-oss-version:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     secrets: inherit
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,5 @@ jobs:
 
   dependabot:
     needs: [ authorize, build-test ]
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request includes updates to several GitHub workflow files to use the latest version of shared workflow logic from the `main` branch instead of a specific version tag.

Updates to GitHub workflow files:

* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6L11-R11): Updated to use `liquibase/build-logic/.github/workflows/pro-extension-test.yml@main` for nightly builds.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L19-R19): Updated to use `liquibase/build-logic/.github/workflows/codeql.yml@main` for CodeQL analysis.
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L12-R12): Updated to use `liquibase/build-logic/.github/workflows/create-release.yml@main` for creating releases.
* [`.github/workflows/extension-update-pom.yml`](diffhunk://#diff-35ee91f4e3955b6c04bf362154b8885c757e251746e45d64bc5494ffd81b5270L10-R10): Updated to use `liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main` for updating POM OSS versions.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-R25): Updated to use `liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main` for dependabot automerge.