### PR TITLE
DAT-19434: Update deploy-extension-to-marketplace.yml

### DIFF
--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -18,8 +18,6 @@ on:
       - main
     types:
       - closed
-    paths:
-      - 'Dockerfile'
 
 jobs:
 #  https://datical.atlassian.net/browse/DAT-18638

--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -61,7 +61,7 @@ jobs:
           echo "versions_match is set to: ${{ steps.check_versions.outputs.versions_match }}"
 
   build:
-      if: github.actor == 'dependabot' && ${{ needs.check-OSS-version.outputs.OSS_VERSION_MATCH }} == true
+      if: github.actor == 'dependabot' && ${{ needs.check-OSS-version.outputs.OSS_VERSION_MATCH }} == true && ${{ inputs.dry_run == false }}
       runs-on:
           ubuntu-latest
       permissions:

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Extension which validates licenses using AWS License Manager
 # :outbox_tray: Deploying the extension to Liquibase AWS Marketplace
 
 1. The `extension-update-pom.yml` file updates the Liquibase version of the extension in the `pom.xml` file whenever there is a **new Liquibase Release**. It listens to the `repository_dispatch` event called `oss-released-version` from the `liquibase/liquibase` repository and then runs the workflow specified in the `extension-update-pom.yml` file.
-2. We release a new version of `liquibase-aws-license-service` only when it is required, as this is a PRO extension.
-3. When there is a new `liquibase-aws-license-service` version release, the dependabot in LPM(liquibase package manager) repository creates a PR: example : https://github.com/liquibase/liquibase-package-manager/pull/430/files#diff-0b0a9d274bd84c7dbfff4680de10599cd0d96458b06b74a925b2bcd3e3fc2fadR15. We need to **manually** merge the PR. Make sure to review and merge the PR before proceeding.
-4. The below steps run on every OSS release.
+2. Make sure both the dependabot PR's for changes in `pom.xml` and `Dockerfile` are merged before you test the workflow [deploy-extension-to-marketplace.yml](https://github.com/liquibase/liquibase-aws-license-service/blob/main/.github/workflows/deploy-extension-to-marketplace.yml)
+3. We release a new version of `liquibase-aws-license-service` only when it is required, as this is a PRO extension.
+4. When there is a new `liquibase-aws-license-service` version release, the dependabot in LPM(liquibase package manager) repository creates a PR: example : https://github.com/liquibase/liquibase-package-manager/pull/430/files#diff-0b0a9d274bd84c7dbfff4680de10599cd0d96458b06b74a925b2bcd3e3fc2fadR15. We need to **manually** merge the PR. Make sure to review and merge the PR before proceeding.
+5. The below steps run on every OSS release.
    - **a.** The `dependabot.yml` file checks for new versions of dependencies for `package-ecosystem: "docker"` and creates a pull request to update the dependencies, specifically for new version of liquibase docker .
    - **b.** The workflow file `dependabot-pr-merge-docker-changes.yml` auto merges the dependabot PR containing the new Docker OSS version, 
    - **c.** The `deploy-extension-to-marketplace.yml` file runs and publishes the extension to the `Liquibase AWS Marketplace`.
@@ -45,4 +46,4 @@ Extension which validates licenses using AWS License Manager
 
 8. To add more commands to test in the `aws-mp-test-cluster`, you can add them in the `Task Definitions` section.
 9. Contact the DevOps team to get access to the `LiquibaseAWSMP` AWS account or any other help required.
-
+10. **After testing** run the workflow [deploy-extension-to-marketplace.yml](https://github.com/liquibase/liquibase-aws-license-service/blob/main/.github/workflows/deploy-extension-to-marketplace.yml) with actual value eg: `4.31.0` with **disabled** "Run this as dry run"


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to 

1. add a condition for running the `build` job. The change ensures that the `build` job only runs if it is not a dry run.
2. Tests should run first and then [deploy-extension-to-marketplace.yml](https://github.com/liquibase/liquibase-aws-license-service/blob/main/.github/workflows/deploy-extension-to-marketplace.yml)   should be run manually. cc: @rberezen 

Workflow configuration:

* [`.github/workflows/deploy-extension-to-marketplace.yml`](diffhunk://#diff-3c746d30714ebf2e3ecea3317afb825b8ee2e00847ce7f00cc9d1602151667cdL64-R64): Added a condition to the `build` job to check if `inputs.dry_run` is `false`.