### PR TITLE
🛠️ DAT-19435: add provenance: false

### DIFF
--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -61,7 +61,7 @@ jobs:
           echo "versions_match is set to: ${{ steps.check_versions.outputs.versions_match }}"
 
   build:
-      if: github.actor == 'dependabot' && ${{ needs.check-OSS-version.outputs.OSS_VERSION_MATCH }} == true && ${{ inputs.dry_run == false }}
+      if: github.actor == 'dependabot' && ${{ needs.check-OSS-version.outputs.OSS_VERSION_MATCH }} == true && ${{ inputs.dry_run }} == 'false'
       runs-on:
           ubuntu-latest
       permissions:

--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -110,6 +110,7 @@ jobs:
               no-cache: true
               push: true
               platforms: linux/amd64,linux/arm64
+              provenance: false # Disables the generation of provenance attestation
               tags: ${{ secrets.AWS_MP_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.get_latest_tag.outputs.LATEST_TAG }}
             continue-on-error: true
 
@@ -166,6 +167,7 @@ jobs:
           no-cache: true
           push: true
           platforms: linux/amd64,linux/arm64
+          provenance: false # Disables the generation of provenance attestation
           tags: ${{ secrets.AWS_MP_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ github.event.inputs.image_tag }}
         continue-on-error: true
 


### PR DESCRIPTION
- This pull request includes changes to the `.github/workflows/deploy-extension-to-marketplace.yml` file to disable the generation of provenance attestation in two job steps. 
- AWS Marketplace listing scanners currently do not support images with attestation layers. They are working on a fix to ignore these layers. In the meanwhile we need to pass `provenance:false`.
- What is `provenance attestation`: In the context of Docker builds and container supply chains, provenance attestations refer to metadata that describes how, when, and by whom a container image or artifact was created. Read more about it here: https://docs.docker.com/build/metadata/attestations/slsa-provenance/

Changes to deployment workflow:

* Modified the condition for the `build` job to correctly compare the `dry_run` input as a string. 
* Added the `provenance: false` configuration to disable the generation of provenance attestation in two places within the `build` job.