### PR TITLE
DAT-19508 DevOps :: Update AWS MP container with liquibase-aws-extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Liquibase image as the base
-FROM liquibase/liquibase:4.31.0
+FROM liquibase/liquibase:4.31.1
 
 # Marker which indicates this is a Liquibase docker container
 ENV DOCKER_AWS_LIQUIBASE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ ENV DOCKER_AWS_LIQUIBASE=true
 RUN lpm update && \
     lpm add \
     liquibase-aws-license-service \
-    liquibase-s3-extension \
-    liquibase-aws-secrets-manager \
-    liquibase-commercial-mongodb \
-    liquibase-commercial-dynamodb \
+    liquibase-aws-extension \
     --global
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <liquibase.version>4.31.0</liquibase.version>
+        <liquibase.version>4.31.1</liquibase.version>
         <sonar.tests>src/test/groovy</sonar.tests>
     </properties>
 


### PR DESCRIPTION
This pull request includes a change to the `Dockerfile` to update the list of Liquibase extensions being added.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R11): Replaced `liquibase-s3-extension`, `liquibase-aws-secrets-manager`, `liquibase-commercial-mongodb`, and `liquibase-commercial-dynamodb` with `liquibase-aws-extension`.