### PR TITLE
🔧 DAT-19696: Remove latest from dry-run tag

### DIFF
--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -149,6 +149,13 @@ jobs:
           username: ${{ secrets.AWS_MP_ACCESS_KEY }}
           password: ${{ secrets.AWS_MP_ACCESS_KEY_ID }}
 
+      - name: debug     
+        run: |
+          echo "REGISTRY=${{ secrets.AWS_MP_REGISTRY }}"
+          echo "REPOSITORY=${{ secrets.ECR_REPOSITORY }}"
+          echo "TAG=${{ github.event.inputs.image_tag }}"
+
+          
       - name: Build and Push Docker Image
         env:
           ECR_REGISTRY: ${{ secrets.AWS_MP_REGISTRY }}
@@ -166,7 +173,7 @@ jobs:
       - name: Submit New Version Request for AWS MP Listing
         env:
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: "${{ github.event.inputs.image_tag }}-latest"
+          IMAGE_TAG: "${{ github.event.inputs.image_tag }}"
           PRODUCT_ID: ${{ secrets.PRODUCT_ID }}
           AWS_MP_REGISTRY: ${{ secrets.AWS_MP_REGISTRY }}
         run: |

--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -148,13 +148,6 @@ jobs:
           registry: ${{ secrets.AWS_MP_REGISTRY }}
           username: ${{ secrets.AWS_MP_ACCESS_KEY }}
           password: ${{ secrets.AWS_MP_ACCESS_KEY_ID }}
-
-      - name: debug     
-        run: |
-          echo "REGISTRY=${{ secrets.AWS_MP_REGISTRY }}"
-          echo "REPOSITORY=${{ secrets.ECR_REPOSITORY }}"
-          echo "TAG=${{ github.event.inputs.image_tag }}"
-
           
       - name: Build and Push Docker Image
         env:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/deploy-extension-to-marketplace.yml` file. The change modifies the `IMAGE_TAG` environment variable to remove the `-latest` suffix, ensuring the tag directly reflects the input provided.

* Workflow update:
  * [`.github/workflows/deploy-extension-to-marketplace.yml`](diffhunk://#diff-3c746d30714ebf2e3ecea3317afb825b8ee2e00847ce7f00cc9d1602151667cdL169-R169): Updated the `IMAGE_TAG` environment variable to use the exact value from `${{ github.event.inputs.image_tag }}` without appending `-latest`.