### PR TITLE
🔧 DAT-20177: use GITHUB_TOKEN in place of BOT_TOKEN

### DIFF
--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -23,4 +23,4 @@ jobs:
         run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.BOT_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - Dockerfile  # This ensures the workflow only runs when the Dockerfile is changed.
-
+  schedule:
+    - cron: '0 * * * *'  # Runs at the top of every hour (UTC)
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -23,4 +23,3 @@ jobs:
         run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN lpm update && \
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,3 @@ RUN lpm update && \
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]
-


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/dependabot-pr-merge-docker-changes.yml` file. The change replaces the `GH_TOKEN` environment variable to use `secrets.GITHUB_TOKEN` instead of `secrets.BOT_TOKEN` for authentication.