### PR TITLE
DAT-20177: Remove cron job and wait for dependabot to trigger the job 

### DIFF
--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - Dockerfile  # This ensures the workflow only runs when the Dockerfile is changed.
-  schedule:
-    - cron: '*/15 * * * *'  # Runs at the top of every hour (UTC)
 permissions:
   contents: write
   pull-requests: write
@@ -13,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -23,4 +23,4 @@ jobs:
         run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.BOT_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - Dockerfile  # This ensures the workflow only runs when the Dockerfile is changed.
   schedule:
-    - cron: '0 * * * *'  # Runs at the top of every hour (UTC)
+    - cron: '*/15 * * * *'  # Runs at the top of every hour (UTC)
 permissions:
   contents: write
   pull-requests: write
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - Dockerfile  # This ensures the workflow only runs when the Dockerfile is changed.
-
+  schedule:
+    - cron: '0 * * * *'  # Runs at the top of every hour (UTC)
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.repository == 'liquibase/liquibase-aws-license-service'
+    if: github.actor == 'dependabot[bot]' && github.repository == 'liquibase/liquibase-aws-license-service'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -23,4 +23,3 @@ jobs:
         run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN lpm update && \
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,3 @@ RUN lpm update && \
 
 # Default command to display Liquibase version
 CMD ["liquibase", "--help"]
-


### PR DESCRIPTION
This pull request modifies the `.github/workflows/dependabot-pr-merge-docker-changes.yml` file to adjust the workflow's trigger conditions by removing the scheduled execution.

Workflow trigger adjustments:

* Removed the `schedule` trigger that ran the workflow at the top of every hour (UTC), ensuring the workflow now only runs for `pull_request` events affecting the `Dockerfile`.