### PR TITLE
🔧 DAT-20177: Update yml file LIQUIBOT_PAT_GPM_ACCESS

### DIFF
--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -17,8 +17,9 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.LIQUIBOT_PAT_GPM_ACCESS}}

--- a/.github/workflows/dependabot-pr-merge-docker-changes.yml
+++ b/.github/workflows/dependabot-pr-merge-docker-changes.yml
@@ -17,7 +17,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --merge "$PR_URL"
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a different token for Dependabot metadata fetching.

* [`.github/workflows/dependabot-pr-merge-docker-changes.yml`](diffhunk://#diff-a6fd38621293d98e37cc51bf7db52ea397d99b1f172695347b2ccb8a18a1bfa2L20-R20): Replaced the `github-token` value from `${{ secrets.GITHUB_TOKEN }}` to `${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}` in the `dependabot/fetch-metadata` action.


It was using a `BOT_TOKEN` before. I had made changes to this workflow to test if it would work with just `GITHUB_TOKEN` but it dint:

https://github.com/liquibase/liquibase-aws-license-service/actions/runs/13391205709/workflow#L26

<img width="1402" alt="Screenshot 2025-05-14 at 2 21 40 PM" src="https://github.com/user-attachments/assets/c175c555-311f-471a-a96f-fb2ff9f7b1d6" />
