### PR TITLE
remove -latest from tag

### DIFF
--- a/.github/workflows/deploy-extension-to-marketplace.yml
+++ b/.github/workflows/deploy-extension-to-marketplace.yml
@@ -109,7 +109,7 @@ jobs:
           - name: Submit Request for AWS MP Listing
             env:
               ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-              IMAGE_TAG: "${{ steps.get_latest_tag.outputs.LATEST_TAG }}-latest"
+              IMAGE_TAG: "${{ steps.get_latest_tag.outputs.LATEST_TAG }}"
               PRODUCT_ID: ${{ secrets.PRODUCT_ID }}
               AWS_MP_REGISTRY: ${{ secrets.AWS_MP_REGISTRY }}
             run: |


### PR DESCRIPTION
This pull request includes a minor adjustment to the deployment workflow for the AWS Marketplace listing. The change removes the `-latest` suffix from the `IMAGE_TAG` value to use the exact latest tag retrieved from the `get_latest_tag` step.

When we append the `latest` tag the request fails 
https://aws.amazon.com/marketplace/pp/prodview-hjwjlndyfbvtm
<img width="1817" alt="Screenshot 2025-05-28 at 11 52 38 AM" src="https://github.com/user-attachments/assets/08c51ba5-7910-4e7c-952b-c08d4caed896" />

<img width="1571" alt="Screenshot 2025-05-28 at 11 53 51 AM" src="https://github.com/user-attachments/assets/28018197-f8f9-40f8-8f6f-ab87eb87d277" />


listing approved
<img width="1693" alt="Screenshot 2025-05-28 at 1 02 00 PM" src="https://github.com/user-attachments/assets/1b4363e0-bfca-4fb9-9d21-d04e36e776c3" />
