### PR TITLE
DAT-19747: add permissions based on the inherited workflows from build-logic

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   nightly-build:
-    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@DAT-19747
+    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,10 +13,12 @@ permissions:
 
 jobs:
   nightly-build:
-    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main
+    uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@DAT-19747
     permissions:
       contents: write
       id-token: write
+      packages: read
+      pull-requests: write
     with:
       nightly: true
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   nightly-build:
     uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main
+    permissions:
+      contents: write
+      id-token: write
     with:
       nightly: true
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -6,11 +6,6 @@ on:
   schedule:
     - cron: "0 7 * * 1-5"
 
-permissions:
-  contents: read
-  pull-requests: write
-  packages: read
-
 jobs:
   nightly-build:
     uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -56,6 +56,9 @@ jobs:
     needs: dry-run-get-draft-release
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
     secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
     with:
       dry_run: true
       dry_run_version: "0.0.${{ github.run_number }}"

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -58,7 +58,9 @@ jobs:
     secrets: inherit
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      packages: write
+      pull-requests: write
     with:
       dry_run: true
       dry_run_version: "0.0.${{ github.run_number }}"


### PR DESCRIPTION
This pull request updates permissions in two GitHub Actions workflow files to ensure proper access control during their execution. The changes primarily involve adding specific permissions for `contents`, `id-token`, `packages`, and `pull-requests` to the workflows.

**NOTE**: run for Dry run release runs only on main/master as there is a check for it [here](https://github.com/liquibase/liquibase-aws-license-service/actions/runs/15715613482/job/44284457878#step:12:277) therefore run from main after the merge of PR

### Permissions updates:

* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6L16-R21): Added permissions (`contents: write`, `id-token: write`, `packages: read`, `pull-requests: write`) to the `nightly-build` job to align with the updated workflow reference.
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR59-R63): Added permissions (`id-token: write`, `contents: write`, `packages: write`, `pull-requests: write`) to the `dry-run-release` job for enhanced access control during dry-run operations.