### PR TITLE
DAT-20693: Update liquibase-secure.version to 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>com.liquibase</groupId>
-            <artifactId>liquibase-pro</artifactId>
+            <artifactId>liquibase-commercial</artifactId>
             <version>${liquibase-secure.version}</version>
 <!--            liquibase-core is included and marked as provided because the parent-pom does not mark it as provided, but it needs to be-->
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <liquibase-secure.version>5.0.0-SNAPSHOT</liquibase-secure.version>
+        <liquibase-secure.version>5.0.0</liquibase-secure.version>
         <sonar.tests>src/test/groovy</sonar.tests>
     </properties>
 


### PR DESCRIPTION
This pull request updates the Liquibase dependency configuration in the `pom.xml` file to use the stable release and the correct artifact name. These changes ensure the project uses the appropriate commercial version of Liquibase and a stable dependency version.

Dependency configuration updates:

* Changed the `liquibase-secure.version` property from `5.0.0-SNAPSHOT` (a development snapshot) to the stable release `5.0.0`.
* Updated the dependency artifact from `liquibase-pro` to `liquibase-commercial` to reflect the correct commercial artifact.