### PR TITLE
[TECHOPS-622] Align AWS SDK to 2.42.38 via BOM (fix XXHASH3 clash)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,26 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <liquibase-secure.version>5.2.0</liquibase-secure.version>
     <sonar.tests>src/test/groovy</sonar.tests>
+    <!-- Must match amazon.aws.version in liquibase-aws-extension so the shaded AWS SDK
+         in the Secure image stays on a single version (avoids the XXHASH3 checksums
+         clash). See TECHOPS-622. -->
+    <amazon.aws.version>2.42.38</amazon.aws.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Pin every software.amazon.awssdk:* artifact (incl. checksums / checksums-spi)
+           to one consistent version so the license-service jar does not drift ahead of
+           the S3/DynamoDB extension bundled in the same image. -->
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${amazon.aws.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.liquibase</groupId>
@@ -41,7 +60,9 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>licensemanager</artifactId>
-      <version>2.46.7</version>
+      <!-- Version managed by the AWS SDK BOM (amazon.aws.version) above. Do not pin here:
+           a standalone version let Dependabot bump it ahead of the bundled S3/DynamoDB
+           extension and broke the test-5.2.0 image (TECHOPS-622). -->
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
## What problem does it solve?

The `update-command-dynamodb` ECS test in `run-task-definitions.yml` fails for the `test-5.2.0` Liquibase Secure image with:

```
Class software.amazon.awssdk.checksums.DefaultChecksumAlgorithm does not have member field
'software.amazon.awssdk.checksums.spi.ChecksumAlgorithm XXHASH3'
```

Failing job: https://github.com/liquibase/liquibase-aws-license-service/actions/runs/27285701382/job/80592200604

**Root cause:** the image ends up with two shaded copies of the AWS SDK that straddle the 2.42 release where the `XXHASH3` checksums field was introduced.

- The published [v1.0.4](https://github.com/liquibase/liquibase-aws-license-service/releases/tag/v1.0.4) license-service jar that `lpm` installs shades AWS SDK **2.40.2**, whose `DefaultChecksumAlgorithm` has **no** `XXHASH3` field.
- The bundled `liquibase-aws-extension` is on the 2.42 line ([crossed into it on 2026-03-02](https://github.com/liquibase/liquibase-aws-extension/pull/740); 5.2 ships **2.42.40**), which has and references `XXHASH3` on the S3 checksum path.

At runtime the older 2.40.2 `DefaultChecksumAlgorithm` wins on the classpath while the newer extension code calls `XXHASH3`, giving `NoSuchFieldError`. Only S3-touching commands hit it (the update reads its changelog/properties from `s3://...`); `version-command` passes because it never loads the SDK.

Note: the pom had separately drifted to a standalone `licensemanager` `2.46.7` via Dependabot ([#575](https://github.com/liquibase/liquibase-aws-license-service/pull/575)), but that was never released into an image, so the operative version in the failing test was the v1.0.4 jar at **2.40.2** (the older copy that lacks the field), not 2.46.7.

## The fix

Import the AWS SDK BOM at `amazon.aws.version=2.42.38` and drop the standalone `licensemanager` version so the BOM manages every `software.amazon.awssdk:*` artifact at one consistent version on the 2.42 line, matching `liquibase-aws-extension` (so `XXHASH3` is present everywhere). Follow-up [#578](https://github.com/liquibase/liquibase-aws-license-service/pull/578) bumps this to 2.42.40 to match the bundled extension exactly.

## How it was tested

`mvn dependency:tree -Dincludes=software.amazon.awssdk` shows BUILD SUCCESS; `licensemanager` and all transitives (incl. `checksums` and `checksums-spi`) now resolve to **2.42.38**.

A new `test-` image must be built from this change and re-run through `run-task-definitions.yml` to confirm `update-command-dynamodb` passes end-to-end.

## Notes

- Jira: TECHOPS-622 (child of TECHOPS-614). Separate from TECHOPS-621 (marketplace polling pipeline).
- Follow-up: keep Dependabot from re-pinning awssdk ahead of the BOM (ignore the standalone bump), done in [#580](https://github.com/liquibase/liquibase-aws-license-service/pull/580).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
