### PR TITLE
Update pom.xml aws version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <!-- Must match amazon.aws.version in liquibase-aws-extension so the shaded AWS SDK
          in the Secure image stays on a single version (avoids the XXHASH3 checksums
          clash). See TECHOPS-622. -->
-    <amazon.aws.version>2.42.38</amazon.aws.version>
+    <amazon.aws.version>2.42.40</amazon.aws.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Pin to the exact AWS SDK version shaded into liquibase-aws-extension.jar in the  liquibase-secure:5.2.0 base image (verified: 2.42.40). 
This update to just to ensure exact version match to avoid doing a release of `liquibase-aws-license-service` again.