### PR TITLE
[TECHOPS-622] Pin AWS SDK to 2.42.40, block Dependabot, and guard against drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
     pull-request-branch-name:
       separator: "-"
     labels: ["sdou"]
+    # amazon.aws.version must stay matched to the AWS SDK bundled in the
+    # liquibase-aws-extension inside the Secure base image (2.42.40). Letting
+    # Dependabot bump it ahead re-introduces the XXHASH3 checksums clash that
+    # broke the test-5.2.0 image. See TECHOPS-622. Bump this manually, in
+    # lockstep with the extension, only.
+    ignore:
+      - dependency-name: "software.amazon.awssdk:*"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,62 @@ jobs:
     steps:
       - run: "true"
 
+  # Guard: the AWS SDK shaded into this jar must stay on the same version as the
+  # SDK bundled in liquibase-aws-extension inside the Secure base image. When they
+  # drift the classpath carries two SDK versions and the older one wins for some
+  # classes -> NoSuchFieldError (the XXHASH3 checksums clash, TECHOPS-622). This
+  # fails the build on drift so a skewed jar can never be released. It replaces
+  # the (wrong) safety net Dependabot used to provide before it was blocked from
+  # bumping software.amazon.awssdk:* in .github/dependabot.yml.
+  verify-amazon-aws-version:
+    needs: authorize
+    runs-on: ubuntu-latest
+    # Reads the private liquibase-pro repo via the vault PAT; skip on forks where
+    # the OIDC role / PAT are unavailable so external PRs are not blocked.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify amazon.aws.version matches liquibase-aws-extension
+        env:
+          GH_TOKEN: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+        run: |
+          set -euo pipefail
+          UPSTREAM=$(gh api "repos/liquibase/liquibase-pro/contents/cloud-integrations/liquibase-aws-extension/pom.xml" --jq '.content' \
+            | base64 -d \
+            | grep -oE '<amazon.aws.version>[^<]+</amazon.aws.version>' \
+            | head -1 \
+            | sed -E 's/<\/?amazon.aws.version>//g')
+          LOCAL=$(grep -oE '<amazon.aws.version>[^<]+</amazon.aws.version>' pom.xml \
+            | head -1 \
+            | sed -E 's/<\/?amazon.aws.version>//g')
+          echo "liquibase-aws-extension (source of truth): ${UPSTREAM:-<empty>}"
+          echo "liquibase-aws-license-service (this repo):  ${LOCAL:-<empty>}"
+          if [ -z "$UPSTREAM" ]; then
+            echo "::error::Could not read amazon.aws.version from liquibase-aws-extension pom"
+            exit 1
+          fi
+          if [ "$UPSTREAM" != "$LOCAL" ]; then
+            echo "::error::amazon.aws.version drift: this repo pins $LOCAL but liquibase-aws-extension bundles $UPSTREAM. The shaded AWS SDK must match the SDK in the Secure base image (TECHOPS-622). Update <amazon.aws.version> in pom.xml to $UPSTREAM."
+            exit 1
+          fi
+          echo "✅ amazon.aws.version is in sync at $LOCAL"
+
   build-test:
     needs: authorize
     uses: liquibase/build-logic/.github/workflows/pro-extension-test.yml@main

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <!-- Must match amazon.aws.version in liquibase-aws-extension so the shaded AWS SDK
          in the Secure image stays on a single version (avoids the XXHASH3 checksums
          clash). See TECHOPS-622. -->
-    <amazon.aws.version>2.46.8</amazon.aws.version>
+    <amazon.aws.version>2.42.40</amazon.aws.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## What & why
Dependabot ([#579](https://github.com/liquibase/liquibase-aws-license-service/pull/579)) bumped `amazon.aws.version` `2.42.40` → `2.46.8`, which shipped in **v1.0.5**. That pushes the license-service AWS SDK **ahead** of the `2.42.40` SDK bundled in `liquibase-aws-extension` inside the `liquibase/liquibase-secure:5.2.0` base image — the exact non-uniform classpath that caused the XXHASH3 checksums clash (`NoSuchFieldError: ... XXHASH3`) and broke the `test-5.2.0` `update-command-dynamodb` ECS task.

This restores the intended state and makes the skew impossible to reintroduce.

## Changes
1. **`pom.xml`** — `amazon.aws.version` `2.46.8` → `2.42.40`, matching the base image's bundled extension exactly.
2. **`.github/dependabot.yml`** — `ignore` `software.amazon.awssdk:*` so Dependabot can no longer bump the BOM ahead of the extension. This property is now bumped only in lockstep with the extension.
3. **`.github/workflows/test.yml`** — new `verify-amazon-aws-version` job (the guard): reads `<amazon.aws.version>` from the `liquibase-aws-extension` pom (source of truth in `liquibase-pro`) and **fails the build** if this repo's pom doesn't match. Runs on every PR, so drift from *any* source — Dependabot, a human edit, a stale branch — is blocked rather than left for a sync job to fix after the fact. Skips on forks where the vault PAT is unavailable.

Design note: a fail-fast guard is preferred over an auto-sync/poll job — it *enforces* the invariant on every build instead of *hoping* an automation fires on the right event. To make it blocking on merge, add `verify-amazon-aws-version` to the branch's required status checks.

## Verification
`mvn dependency:tree -Dincludes=software.amazon.awssdk` → **BUILD SUCCESS**; `licensemanager` and all transitives, including `checksums` / `checksums-spi` (the XXHASH3 carriers), resolve uniformly to **2.42.40**.

## Follow-up
A new release (v1.0.6) is needed for LPM to serve this aligned jar; `lpm update` then pulls it from `main` (no LPM release required). Re-run `run-task-definitions.yml` against a rebuilt image to confirm `update-command-dynamodb` passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)