### PR TITLE
[TECHOPS-621] Align run-task-definitions.yml DynamoDB attribute names to table (camelCase)

### DIFF
--- a/.github/workflows/run-task-definitions.yml
+++ b/.github/workflows/run-task-definitions.yml
@@ -191,7 +191,7 @@ jobs:
       #
       # What happens next:
       #   1. Test image restriction completes (~15 min)
-      #   2. Lambda polls and finds TestStatus=completed in DynamoDB
+      #   2. Lambda polls and finds testStatus=completed in DynamoDB
       #   3. Lambda verifies restriction change set has Status=SUCCEEDED
       #   4. Lambda triggers deploy-extension-to-marketplace.yml (dry_run=false)
       #   5. Production version submitted to AWS Marketplace
@@ -210,11 +210,11 @@ jobs:
           # Find the change set ID for this image tag
           CHANGE_SETS=$(aws dynamodb scan \
             --table-name liquibase-secure-marketplace-changesets \
-            --filter-expression "ImageTag = :tag" \
+            --filter-expression "imageTag = :tag" \
             --expression-attribute-values '{":tag":{"S":"'"$IMAGE_TAG"'"}}' \
             --region us-east-1)
 
-          CHANGESET_ID=$(echo "$CHANGE_SETS" | jq -r '.Items[0].ChangeSetId.S // empty')
+          CHANGESET_ID=$(echo "$CHANGE_SETS" | jq -r '.Items[0].changeSetId.S // empty')
 
           if [ -n "$CHANGESET_ID" ]; then
             echo "Found change set: $CHANGESET_ID for image tag: $IMAGE_TAG"
@@ -222,8 +222,8 @@ jobs:
             # Update the item to mark TaskDefinition as completed
             aws dynamodb update-item \
               --table-name liquibase-secure-marketplace-changesets \
-              --key '{"ChangeSetId":{"S":"'"$CHANGESET_ID"'"}}' \
-              --update-expression "SET TestStatus = :status, TestCompletedAt = :timestamp" \
+              --key '{"changeSetId":{"S":"'"$CHANGESET_ID"'"}}' \
+              --update-expression "SET testStatus = :status, testCompletedAt = :timestamp" \
               --expression-attribute-values '{":status":{"S":"completed"},":timestamp":{"S":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}}' \
               --region us-east-1
 


### PR DESCRIPTION
Implements root cause #3 of [TECHOPS-621](https://datical.atlassian.net/browse/TECHOPS-621) (child of [TECHOPS-614](https://datical.atlassian.net/browse/TECHOPS-614)).

## Problem
The `restrict-marketplace-listing` job in `run-task-definitions.yml` references the tracking table `liquibase-secure-marketplace-changesets` using **PascalCase** attribute names, but the table schema is **camelCase**. The mismatch breaks the "tests passed → production release" handoff — the `scan` filter matches nothing and `update-item` writes the wrong attributes — and leaves the TTL/StatusIndex unpopulated.

## Change (minimal — workflow field names only)
| Before | After |
|---|---|
| `ImageTag` | `imageTag` |
| `ChangeSetId` | `changeSetId` |
| `TestStatus` | `testStatus` |
| `TestCompletedAt` | `testCompletedAt` |

5 lines in `run-task-definitions.yml`; no other files.

## Notes
- Re-cut clean off current `main`. The original `fix/dynamodb-key-schema-TECHOPS-621` branch had drifted and would have reverted merged work (the dependabot ignore, the `test.yml` guard, the pom BOM pin) — this PR contains only the field renames.
- The Lambda-code half of the same camelCase fix is deployed separately (the Lambda code isn't in a repo).
- Companion infra fix for this ticket: [liquibase-infrastructure#3842](https://github.com/liquibase/liquibase-infrastructure/pull/3842) (handler + token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-621]: https://datical.atlassian.net/browse/TECHOPS-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-614]: https://datical.atlassian.net/browse/TECHOPS-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ